### PR TITLE
Fix screenshot example

### DIFF
--- a/examples/screenshot.rs
+++ b/examples/screenshot.rs
@@ -12,7 +12,7 @@ fn main() {
     let one_frame = one_second / 60;
 
     let display = Display::primary().expect("Couldn't find primary display.");
-    let mut capturer = Capturer::new(display).expect("Couldn't begin capture.");
+    let mut capturer = Capturer::new(&display).expect("Couldn't begin capture.");
     let (w, h) = (capturer.width(), capturer.height());
 
     loop {


### PR DESCRIPTION
 * API seems to have changed to take a refernce to a `Display` rather than a `Display` directly.