### PR TITLE
Add Display.top() + left(), useful for combining multi-monitor captures

### DIFF
--- a/src/common/dxgi.rs
+++ b/src/common/dxgi.rs
@@ -68,4 +68,20 @@ impl Display {
     pub fn height(&self) -> usize {
         self.0.height() as usize
     }
+
+    pub fn top(&self) -> i32 {
+        self.0.top()
+    }
+
+    pub fn bottom(&self) -> i32 {
+        self.0.bottom()
+    }
+
+    pub fn left(&self) -> i32 {
+        self.0.left()
+    }
+
+    pub fn right(&self) -> i32 {
+        self.0.right()
+    }
 }

--- a/src/common/quartz.rs
+++ b/src/common/quartz.rs
@@ -97,4 +97,20 @@ impl Display {
     pub fn height(&self) -> usize {
         self.0.height()
     }
+
+    pub fn top(&self) -> i32 {
+        self.0.top() as i32
+    }
+
+    pub fn bottom(&self) -> i32 {
+        (self.0.top() as i32) + (self.0.height() as i32)
+    }
+
+    pub fn left(&self) -> i32 {
+        self.0.left() as i32
+    }
+
+    pub fn right(&self) -> i32 {
+        (self.0.left() as i32) + (self.0.width() as i32)
+    }
 }

--- a/src/common/x11.rs
+++ b/src/common/x11.rs
@@ -68,4 +68,20 @@ impl Display {
     pub fn height(&self) -> usize {
         self.0.rect().h as usize
     }
+
+    pub fn top(&self) -> i32 {
+        self.0.rect().y as i32
+    }
+
+    pub fn bottom(&self) -> i32 {
+        (self.0.rect().y + self.0.rect().h as i16) as i32
+    }
+
+    pub fn left(&self) -> i32 {
+        self.0.rect().x as i32
+    }
+
+    pub fn right(&self) -> i32 {
+        (self.0.rect().x + self.0.rect().w as i16) as i32
+    }
 }

--- a/src/dxgi/mod.rs
+++ b/src/dxgi/mod.rs
@@ -391,6 +391,22 @@ impl Display {
         self.desc.DesktopCoordinates.top
     }
 
+    pub fn top(&self) -> LONG {
+        self.desc.DesktopCoordinates.top
+    }
+
+    pub fn bottom(&self) -> LONG {
+        self.desc.DesktopCoordinates.bottom
+    }
+
+    pub fn left(&self) -> LONG {
+        self.desc.DesktopCoordinates.left
+    }
+
+    pub fn right(&self) -> LONG {
+        self.desc.DesktopCoordinates.right
+    }
+
     pub fn rotation(&self) -> DXGI_MODE_ROTATION {
         self.desc.Rotation
     }

--- a/src/quartz/display.rs
+++ b/src/quartz/display.rs
@@ -40,6 +40,14 @@ impl Display {
         unsafe { CGDisplayPixelsHigh(self.0) }
     }
 
+    pub fn top(self) -> f64 {
+        unsafe { CGDisplayBounds(self.0).origin.y }
+    }
+
+    pub fn left(self) -> f64 {
+        unsafe { CGDisplayBounds(self.0).origin.x }
+    }
+
     pub fn is_builtin(self) -> bool {
         unsafe { CGDisplayIsBuiltin(self.0) != 0 }
     }

--- a/src/quartz/ffi.rs
+++ b/src/quartz/ffi.rs
@@ -126,6 +126,32 @@ pub type FrameAvailableHandler = RcBlock<(
     CGDisplayStreamUpdateRef // updateRef
 ), ()>;
 
+#[cfg(target_pointer_width = "64")]
+pub type CGFloat = libc::c_double;
+#[cfg(not(target_pointer_width = "64"))]
+pub type CGFloat = libc::c_float;
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default)]
+pub struct CGPoint {
+    pub x: CGFloat,
+    pub y: CGFloat,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default)]
+pub struct CGSize {
+    pub width: CGFloat,
+    pub height: CGFloat,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default)]
+pub struct CGRect {
+    pub origin: CGPoint,
+    pub size: CGSize,
+}
+
 #[link(name="System", kind="dylib")]
 #[link(name="CoreGraphics", kind="framework")]
 #[link(name="CoreFoundation", kind="framework")]
@@ -159,6 +185,7 @@ extern {
     pub fn CGMainDisplayID() -> u32;
     pub fn CGDisplayPixelsWide(display: u32) -> usize;
     pub fn CGDisplayPixelsHigh(display: u32) -> usize;
+    pub fn CGDisplayBounds(display: u32) -> CGRect;
 
     pub fn CGGetOnlineDisplayList(
         max_displays: u32,


### PR DESCRIPTION
I wanted to take a screenshot of all my displays as one large image, but found I needed the relative positioning of the displays to arrange the resulting imagebuffers correctly.

top() and left() return `i32`'s, where the first monitor is commonly at `0,0`, and a second monitor positioned to the right and slightly up might be `1920,-100`.
bottom() and right() are convenience methods, which should be equivalent to `top() + height()`, and thus aren't strictly required but are useful.

I have tested this on Windows and Linux, but haven't tried the Mac version (though it compiles on Appveyor at least). This is my first experience with FFI, so there might be a simpler approach to the return struct of CGDisplayBounds...