### PR TITLE
Make buffers mutable

### DIFF
--- a/examples/screenshot.rs
+++ b/examples/screenshot.rs
@@ -18,7 +18,7 @@ fn main() {
     loop {
         // Wait until there's a frame.
 
-        let buffer = match capturer.frame() {
+        let mut buffer = match capturer.frame() {
             Ok(buffer) => buffer,
             Err(error) => {
                 if error.kind() == WouldBlock {
@@ -33,8 +33,7 @@ fn main() {
 
         println!("Captured! Saving...");
 
-        // Flip the ARGB image into a BGRA image.
-
+        // Flip the BGRA image into a RGBA image.
         let mut bitflipped = Vec::with_capacity(w * h * 4);
         let stride = buffer.len() / h;
 
@@ -49,6 +48,17 @@ fn main() {
                 ]);
             }
         }
+
+        // Example doing it in-place with a mutable buffer
+        assert!(buffer.len() % 4 == 0);
+        unsafe {
+            for pixel in buffer.chunks_exact_mut(4) {
+                pixel.get_unchecked_mut(0..3).reverse();
+                *pixel.get_unchecked_mut(3) = 255;
+            }
+        }
+        // they're the same
+        assert_eq!(buffer.to_vec(), bitflipped);
 
         // Save the image.
 

--- a/src/common/x11.rs
+++ b/src/common/x11.rs
@@ -22,12 +22,18 @@ impl Capturer {
     }
 }
 
-pub struct Frame<'a>(&'a [u8]);
+pub struct Frame<'a>(&'a mut [u8]);
 
 impl<'a> ops::Deref for Frame<'a> {
     type Target = [u8];
-    fn deref(&self) -> &[u8] {
+    fn deref(&self) -> &Self::Target {
         self.0
+    }
+}
+
+impl<'a> ops::DerefMut for Frame<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
     }
 }
 

--- a/src/x11/capturer.rs
+++ b/src/x11/capturer.rs
@@ -7,7 +7,7 @@ pub struct Capturer {
     display: Display,
     shmid: i32,
     xcbid: u32,
-    buffer: *const u8,
+    buffer: *mut u8,
 
     request: xcb_shm_get_image_cookie_t,
     loading: usize,
@@ -45,7 +45,7 @@ impl Capturer {
             libc::shmat(
                 shmid,
                 ptr::null(),
-                libc::SHM_RDONLY
+                0
             )
         } as *mut u8;
 
@@ -93,12 +93,12 @@ impl Capturer {
         &self.display
     }
 
-    pub fn frame<'b>(&'b mut self) -> &'b [u8] {
+    pub fn frame<'b>(&'b mut self) -> &'b mut [u8] {
         // Get the return value.
 
         let result = unsafe {
             let off = self.loading & self.size;
-            slice::from_raw_parts(
+            slice::from_raw_parts_mut(
                 self.buffer.offset(off as isize),
                 self.size
             )


### PR DESCRIPTION
You might not want to merge this as-is; dedicated functions could be created for mutable versions, for example `frame_mut()`. This also only covers X11. In any case it's a PoC at least.