### PR TITLE
dxgi::Capturer: fixed memory leak (drop last frame)

### DIFF
--- a/src/dxgi/mod.rs
+++ b/src/dxgi/mod.rs
@@ -225,6 +225,10 @@ impl Capturer {
 impl Drop for Capturer {
     fn drop(&mut self) {
         unsafe {
+            if !self.surface.is_null() {
+                (*self.surface).Unmap();
+                (*self.surface).Release();
+            }
             (*self.duplication).Release();
             (*self.device).Release();
             (*self.context).Release();


### PR DESCRIPTION
I think this is safe? capturer.frame() returns a raw slice that references data stored in `self.surface`, but its lifetime matches the capturer's (if I'm reading those annotations right), so releasing `self.surface` on Capturer drop seems appropriate.

Fixes #25