### PR TITLE
Fix cross-compilation

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,12 +1,16 @@
+use std::env;
+
 fn main() {
-    if cfg!(windows) {
+    if env::var("CARGO_CFG_WINDOWS").is_ok() {
         // The first choice is Windows because DXGI is amazing.
         println!("cargo:rustc-cfg=dxgi");
-    } else if cfg!(target_os="macos") {
+    } else if env::var("CARGO_CFG_TARGET_OS").unwrap() == "macos" {
         // Quartz is second because macOS is the (annoying) exception.
         println!("cargo:rustc-cfg=quartz");
-    } else if cfg!(unix) {
+    } else if env::var("CARGO_CFG_UNIX").is_ok() {
         // On UNIX we pray that X11 (with XCB) is available.
         println!("cargo:rustc-cfg=x11");
+    } else {
+        panic!("Platform not supported");
     }
 }


### PR DESCRIPTION
The current `build.rs` uses `cfg!()` statements to check the build platform, which fails when cross-compiling (e.g. by using [cross](https://github.com/rust-embedded/cross)), because in build scripts those checks return information about the host system rather than the target system.

This PR changes the build script to use the environment variables provided by cargo to hopefully fix cross-compilation without affecting native compilation.

 I've only been able to test Windows and Linux, as I don't have access to a Mac OS system.