### PR TITLE
Update to use 2018 idoms and fmt/clippy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ documentation = "https://docs.rs/scrap"
 keywords = ["screen", "capture", "record"]
 license = "MIT"
 authors = ["Ram <quadrupleslap@gmail.com>"]
+edition = "2018"
 
 [dependencies]
 block = "0.1"

--- a/src/common/dxgi.rs
+++ b/src/common/dxgi.rs
@@ -1,11 +1,12 @@
-use dxgi;
+use crate::dxgi;
+
+use std::io::ErrorKind::{NotFound, TimedOut, WouldBlock};
 use std::{io, ops};
-use std::io::ErrorKind::{WouldBlock, TimedOut, NotFound};
 
 pub struct Capturer {
     inner: dxgi::Capturer,
     width: usize,
-    height: usize
+    height: usize,
 }
 
 impl Capturer {
@@ -13,7 +14,11 @@ impl Capturer {
         let width = display.width();
         let height = display.height();
         let inner = dxgi::Capturer::new(&display.0)?;
-        Ok(Capturer { inner, width, height })
+        Ok(Capturer {
+            inner,
+            width,
+            height,
+        })
     }
 
     pub fn width(&self) -> usize {
@@ -28,10 +33,8 @@ impl Capturer {
         const MILLISECONDS_PER_FRAME: u32 = 0;
         match self.inner.frame(MILLISECONDS_PER_FRAME) {
             Ok(frame) => Ok(Frame(frame)),
-            Err(ref error) if error.kind() == TimedOut => {
-                Err(WouldBlock.into())
-            },
-            Err(error) => Err(error)
+            Err(ref error) if error.kind() == TimedOut => Err(WouldBlock.into()),
+            Err(error) => Err(error),
         }
     }
 }
@@ -51,14 +54,12 @@ impl Display {
     pub fn primary() -> io::Result<Display> {
         match dxgi::Displays::new()?.next() {
             Some(inner) => Ok(Display(inner)),
-            None => Err(NotFound.into())
+            None => Err(NotFound.into()),
         }
     }
 
     pub fn all() -> io::Result<Vec<Display>> {
-        Ok(dxgi::Displays::new()?
-            .map(Display)
-            .collect::<Vec<_>>())
+        Ok(dxgi::Displays::new()?.map(Display).collect::<Vec<_>>())
     }
 
     pub fn width(&self) -> usize {

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,4 +1,4 @@
-cfg_if! {
+cfg_if::cfg_if! {
     if #[cfg(quartz)] {
         mod quartz;
         pub use self::quartz::*;

--- a/src/common/quartz.rs
+++ b/src/common/quartz.rs
@@ -1,11 +1,12 @@
-use quartz;
-use std::{io, ops, mem};
+use crate::quartz;
+
 use std::marker::PhantomData;
 use std::sync::{Arc, Mutex, TryLockError};
+use std::{io, mem, ops};
 
 pub struct Capturer {
     inner: quartz::Capturer,
-    frame: Arc<Mutex<Option<quartz::Frame>>>
+    frame: Arc<Mutex<Option<quartz::Frame>>>,
 }
 
 impl Capturer {
@@ -23,8 +24,9 @@ impl Capturer {
                 if let Ok(mut f) = f.lock() {
                     *f = Some(inner);
                 }
-            }
-        ).map_err(|_| io::Error::from(io::ErrorKind::Other))?;
+            },
+        )
+        .map_err(|_| io::Error::from(io::ErrorKind::Other))?;
 
         Ok(Capturer { inner, frame })
     }
@@ -44,27 +46,20 @@ impl Capturer {
                 mem::swap(&mut frame, &mut handle);
 
                 match frame {
-                    Some(frame) =>
-                        Ok(Frame(frame, PhantomData)),
+                    Some(frame) => Ok(Frame(frame, PhantomData)),
 
-                    None =>
-                        Err(io::ErrorKind::WouldBlock.into())
+                    None => Err(io::ErrorKind::WouldBlock.into()),
                 }
             }
 
-            Err(TryLockError::WouldBlock) =>
-                Err(io::ErrorKind::WouldBlock.into()),
+            Err(TryLockError::WouldBlock) => Err(io::ErrorKind::WouldBlock.into()),
 
-            Err(TryLockError::Poisoned(..)) =>
-                Err(io::ErrorKind::Other.into())
+            Err(TryLockError::Poisoned(..)) => Err(io::ErrorKind::Other.into()),
         }
     }
 }
 
-pub struct Frame<'a>(
-    quartz::Frame,
-    PhantomData<&'a [u8]>
-);
+pub struct Frame<'a>(quartz::Frame, PhantomData<&'a [u8]>);
 
 impl<'a> ops::Deref for Frame<'a> {
     type Target = [u8];
@@ -81,13 +76,11 @@ impl Display {
     }
 
     pub fn all() -> io::Result<Vec<Display>> {
-        Ok(
-            quartz::Display::online()
-                .map_err(|_| io::Error::from(io::ErrorKind::Other))?
-                .into_iter()
-                .map(Display)
-                .collect()
-        )
+        Ok(quartz::Display::online()
+            .map_err(|_| io::Error::from(io::ErrorKind::Other))?
+            .into_iter()
+            .map(Display)
+            .collect())
     }
 
     pub fn width(&self) -> usize {

--- a/src/common/x11.rs
+++ b/src/common/x11.rs
@@ -1,6 +1,7 @@
-use x11;
-use std::{io, ops};
+use crate::x11;
+
 use std::rc::Rc;
+use std::{io, ops};
 
 pub struct Capturer(x11::Capturer);
 
@@ -37,7 +38,7 @@ impl Display {
     pub fn primary() -> io::Result<Display> {
         let server = Rc::new(match x11::Server::default() {
             Ok(server) => server,
-            Err(_) => return Err(io::ErrorKind::ConnectionRefused.into())
+            Err(_) => return Err(io::ErrorKind::ConnectionRefused.into()),
         });
 
         let mut displays = x11::Server::displays(server);
@@ -48,14 +49,14 @@ impl Display {
 
         match best {
             Some(best) => Ok(Display(best)),
-            None => Err(io::ErrorKind::NotFound.into())
+            None => Err(io::ErrorKind::NotFound.into()),
         }
     }
 
     pub fn all() -> io::Result<Vec<Display>> {
         let server = Rc::new(match x11::Server::default() {
             Ok(server) => server,
-            Err(_) => return Err(io::ErrorKind::ConnectionRefused.into())
+            Err(_) => return Err(io::ErrorKind::ConnectionRefused.into()),
         });
 
         Ok(x11::Server::displays(server).map(Display).collect())

--- a/src/dxgi/ffi.rs
+++ b/src/dxgi/ffi.rs
@@ -1,15 +1,6 @@
 use winapi::{
-    GUID,
-    HRESULT,
-    REFIID,
-    IDXGIFactory1,
-    IDXGIAdapter,
-    D3D_DRIVER_TYPE,
-    HMODULE,
-    UINT,
-    ID3D11Device,
-    D3D_FEATURE_LEVEL,
-    ID3D11DeviceContext
+    ID3D11Device, ID3D11DeviceContext, IDXGIAdapter, IDXGIFactory1, D3D_DRIVER_TYPE,
+    D3D_FEATURE_LEVEL, GUID, HMODULE, HRESULT, REFIID, UINT,
 };
 
 pub const DXGI_MAP_READ: UINT = 1;
@@ -18,37 +9,34 @@ pub const IID_IDXGIFACTORY1: GUID = GUID {
     Data1: 0x770aae78,
     Data2: 0xf26f,
     Data3: 0x4dba,
-    Data4: [0xa8, 0x29, 0x25, 0x3c, 0x83, 0xd1, 0xb3, 0x87]
+    Data4: [0xa8, 0x29, 0x25, 0x3c, 0x83, 0xd1, 0xb3, 0x87],
 };
 
 pub const IID_IDXGIOUTPUT1: GUID = GUID {
     Data1: 0x00cddea8,
     Data2: 0x939b,
     Data3: 0x4b83,
-    Data4: [0xa3, 0x40, 0xa6, 0x85, 0x22, 0x66, 0x66, 0xcc]
+    Data4: [0xa3, 0x40, 0xa6, 0x85, 0x22, 0x66, 0x66, 0xcc],
 };
 
 pub const IID_IDXGISURFACE: GUID = GUID {
     Data1: 3405559148,
     Data2: 27331,
     Data3: 18569,
-    Data4: [191, 71, 158, 35, 187, 210, 96, 236]
+    Data4: [191, 71, 158, 35, 187, 210, 96, 236],
 };
 
 pub const IID_ID3D11TEXTURE2D: GUID = GUID {
     Data1: 1863690994,
     Data2: 53768,
     Data3: 20105,
-    Data4: [154, 180, 72, 149, 53, 211, 79, 156]
+    Data4: [154, 180, 72, 149, 53, 211, 79, 156],
 };
 
-#[link(name="dxgi")]
-#[link(name="d3d11")]
+#[link(name = "dxgi")]
+#[link(name = "d3d11")]
 extern "system" {
-    pub fn CreateDXGIFactory1(
-        id: REFIID,
-        pp_factory: *mut *mut IDXGIFactory1
-    ) -> HRESULT;
+    pub fn CreateDXGIFactory1(id: REFIID, pp_factory: *mut *mut IDXGIFactory1) -> HRESULT;
 
     pub fn D3D11CreateDevice(
         pAdapter: *mut IDXGIAdapter,
@@ -60,6 +48,6 @@ extern "system" {
         SDKVersion: UINT,
         ppDevice: *mut *mut ID3D11Device,
         pFeatureLevel: *mut D3D_FEATURE_LEVEL,
-        ppImmediateContext: *mut *mut ID3D11DeviceContext
+        ppImmediateContext: *mut *mut ID3D11DeviceContext,
     ) -> HRESULT;
 }

--- a/src/dxgi/mod.rs
+++ b/src/dxgi/mod.rs
@@ -1,36 +1,15 @@
 use self::ffi::*;
-use std::{io, mem, ptr, slice};
+
 use winapi::{
-    HRESULT,
-    IDXGIAdapter1,
-    IDXGIFactory1,
-    IDXGIOutput1,
-    S_OK,
-    UINT,
-    DXGI_OUTPUT_DESC,
-    LONG,
-    DXGI_MODE_ROTATION,
-    ID3D11Device,
-    ID3D11DeviceContext,
-    IDXGIOutputDuplication,
-    D3D11_SDK_VERSION,
-    D3D_DRIVER_TYPE_UNKNOWN,
-    D3D_FEATURE_LEVEL_9_1,
-    DXGI_ERROR_ACCESS_LOST,
-    DXGI_ERROR_WAIT_TIMEOUT,
-    DXGI_ERROR_INVALID_CALL,
-    E_ACCESSDENIED,
-    DXGI_ERROR_UNSUPPORTED,
-    ID3D11Texture2D,
-    DXGI_ERROR_NOT_CURRENTLY_AVAILABLE,
-    DXGI_ERROR_SESSION_DISCONNECTED,
-    TRUE,
-    IDXGISurface,
-    IDXGIResource,
-    DXGI_RESOURCE_PRIORITY_MAXIMUM,
-    D3D11_CPU_ACCESS_READ,
-    D3D11_USAGE_STAGING
+    ID3D11Device, ID3D11DeviceContext, ID3D11Texture2D, IDXGIAdapter1, IDXGIFactory1, IDXGIOutput1,
+    IDXGIOutputDuplication, IDXGIResource, IDXGISurface, D3D11_CPU_ACCESS_READ, D3D11_SDK_VERSION,
+    D3D11_USAGE_STAGING, D3D_DRIVER_TYPE_UNKNOWN, D3D_FEATURE_LEVEL_9_1, DXGI_ERROR_ACCESS_LOST,
+    DXGI_ERROR_INVALID_CALL, DXGI_ERROR_NOT_CURRENTLY_AVAILABLE, DXGI_ERROR_SESSION_DISCONNECTED,
+    DXGI_ERROR_UNSUPPORTED, DXGI_ERROR_WAIT_TIMEOUT, DXGI_MODE_ROTATION, DXGI_OUTPUT_DESC,
+    DXGI_RESOURCE_PRIORITY_MAXIMUM, E_ACCESSDENIED, HRESULT, LONG, S_OK, TRUE, UINT,
 };
+
+use std::{io, mem, ptr, slice};
 
 mod ffi;
 
@@ -40,8 +19,10 @@ pub struct Capturer {
     device: *mut ID3D11Device,
     context: *mut ID3D11DeviceContext,
     duplication: *mut IDXGIOutputDuplication,
-    fastlane: bool, surface: *mut IDXGISurface,
-    data: *mut u8, len: usize,
+    fastlane: bool,
+    surface: *mut IDXGISurface,
+    data: *mut u8,
+    len: usize,
     height: usize,
 }
 
@@ -57,24 +38,22 @@ impl Capturer {
                 &mut **display.adapter,
                 D3D_DRIVER_TYPE_UNKNOWN,
                 ptr::null_mut(), // No software rasterizer.
-                0, // No device flags.
+                0,               // No device flags.
                 ptr::null_mut(), // Feature levels.
-                0, // Feature levels' length.
+                0,               // Feature levels' length.
                 D3D11_SDK_VERSION,
                 &mut device,
                 &mut D3D_FEATURE_LEVEL_9_1,
-                &mut context
+                &mut context,
             )
-        } != S_OK {
+        } != S_OK
+        {
             // Unknown error.
             return Err(io::ErrorKind::Other.into());
         }
 
         let res = wrap_hresult(unsafe {
-            (*display.inner).DuplicateOutput(
-                &mut **device,
-                &mut duplication
-            )
+            (*display.inner).DuplicateOutput(&mut **device, &mut duplication)
         });
 
         if let Err(err) = res {
@@ -91,12 +70,14 @@ impl Capturer {
 
         Ok(unsafe {
             let mut capturer = Capturer {
-                device, context, duplication,
+                device,
+                context,
+                duplication,
                 fastlane: desc.DesktopImageInSystemMemory == TRUE,
                 surface: ptr::null_mut(),
                 height: display.height() as usize,
                 data: ptr::null_mut(),
-                len: 0
+                len: 0,
             };
             let _ = capturer.load_frame(0);
             capturer
@@ -108,17 +89,11 @@ impl Capturer {
         let mut info = mem::uninitialized();
         self.data = ptr::null_mut();
 
-        wrap_hresult((*self.duplication).AcquireNextFrame(
-            timeout,
-            &mut info,
-            &mut frame
-        ))?;
+        wrap_hresult((*self.duplication).AcquireNextFrame(timeout, &mut info, &mut frame))?;
 
         if self.fastlane {
             let mut rect = mem::uninitialized();
-            let res = wrap_hresult(
-                (*self.duplication).MapDesktopSurface(&mut rect)
-            );
+            let res = wrap_hresult((*self.duplication).MapDesktopSurface(&mut rect));
 
             (*frame).Release();
 
@@ -134,10 +109,7 @@ impl Capturer {
             self.surface = self.ohgodwhat(frame)?;
 
             let mut rect = mem::uninitialized();
-            wrap_hresult((*self.surface).Map(
-                &mut rect,
-                DXGI_MAP_READ
-            ))?;
+            wrap_hresult((*self.surface).Map(&mut rect, DXGI_MAP_READ))?;
 
             self.data = rect.pBits;
             self.len = self.height * rect.Pitch as usize;
@@ -145,14 +117,11 @@ impl Capturer {
         }
     }
 
-    unsafe fn ohgodwhat(
-        &mut self,
-        frame: *mut IDXGIResource
-    ) -> io::Result<*mut IDXGISurface> {
+    unsafe fn ohgodwhat(&mut self, frame: *mut IDXGIResource) -> io::Result<*mut IDXGISurface> {
         let mut texture: *mut ID3D11Texture2D = ptr::null_mut();
         (*frame).QueryInterface(
             &IID_ID3D11TEXTURE2D,
-            &mut texture as *mut *mut _ as *mut *mut _
+            &mut texture as *mut *mut _ as *mut *mut _,
         );
 
         let mut texture_desc = mem::uninitialized();
@@ -167,7 +136,7 @@ impl Capturer {
         let res = wrap_hresult((*self.device).CreateTexture2D(
             &mut texture_desc,
             ptr::null(),
-            &mut readable
+            &mut readable,
         ));
 
         if let Err(err) = res {
@@ -181,13 +150,10 @@ impl Capturer {
             let mut surface = ptr::null_mut();
             (*readable).QueryInterface(
                 &IID_IDXGISURFACE,
-                &mut surface as *mut *mut _ as *mut *mut _
+                &mut surface as *mut *mut _ as *mut *mut _,
             );
 
-            (*self.context).CopyResource(
-                &mut **readable,
-                &mut **texture
-            );
+            (*self.context).CopyResource(&mut **readable, &mut **texture);
 
             (*frame).Release();
             (*texture).Release();
@@ -242,15 +208,13 @@ pub struct Displays {
     /// Index of the CURRENT adapter.
     nadapter: UINT,
     /// Index of the NEXT display to fetch.
-    ndisplay: UINT
+    ndisplay: UINT,
 }
 
 impl Displays {
     pub fn new() -> io::Result<Displays> {
         let mut factory = ptr::null_mut();
-        wrap_hresult(unsafe {
-            CreateDXGIFactory1(&IID_IDXGIFACTORY1, &mut factory)
-        })?;
+        wrap_hresult(unsafe { CreateDXGIFactory1(&IID_IDXGIFACTORY1, &mut factory) })?;
 
         let mut adapter = ptr::null_mut();
         unsafe {
@@ -262,7 +226,7 @@ impl Displays {
             factory,
             adapter,
             nadapter: 0,
-            ndisplay: 0
+            ndisplay: 0,
         })
     }
 
@@ -311,10 +275,7 @@ impl Displays {
 
         let mut inner = ptr::null_mut();
         unsafe {
-            (*output).QueryInterface(
-                &IID_IDXGIOUTPUT1,
-                &mut inner as *mut *mut _ as *mut *mut _
-            );
+            (*output).QueryInterface(&IID_IDXGIOUTPUT1, &mut inner as *mut *mut _ as *mut *mut _);
             (*output).Release();
         }
 
@@ -333,7 +294,11 @@ impl Displays {
             (*self.adapter).AddRef();
         }
 
-        Some(Some(Display { inner, adapter: self.adapter, desc }))
+        Some(Some(Display {
+            inner,
+            adapter: self.adapter,
+            desc,
+        }))
     }
 }
 
@@ -350,10 +315,7 @@ impl Iterator for Displays {
 
             self.adapter = unsafe {
                 let mut adapter = ptr::null_mut();
-                (*self.factory).EnumAdapters1(
-                    self.nadapter,
-                    &mut adapter
-                );
+                (*self.factory).EnumAdapters1(self.nadapter, &mut adapter);
                 adapter
             };
 
@@ -381,18 +343,16 @@ impl Drop for Displays {
 pub struct Display {
     inner: *mut IDXGIOutput1,
     adapter: *mut IDXGIAdapter1,
-    desc: DXGI_OUTPUT_DESC
+    desc: DXGI_OUTPUT_DESC,
 }
 
 impl Display {
     pub fn width(&self) -> LONG {
-        self.desc.DesktopCoordinates.right -
-        self.desc.DesktopCoordinates.left
+        self.desc.DesktopCoordinates.right - self.desc.DesktopCoordinates.left
     }
 
     pub fn height(&self) -> LONG {
-        self.desc.DesktopCoordinates.bottom -
-        self.desc.DesktopCoordinates.top
+        self.desc.DesktopCoordinates.bottom - self.desc.DesktopCoordinates.top
     }
 
     pub fn rotation(&self) -> DXGI_MODE_ROTATION {
@@ -401,9 +361,7 @@ impl Display {
 
     pub fn name(&self) -> &[u16] {
         let s = &self.desc.DeviceName;
-        let i = s.iter()
-            .position(|&x| x == 0)
-            .unwrap_or(s.len());
+        let i = s.iter().position(|&x| x == 0).unwrap_or(s.len());
         &s[..i]
     }
 }
@@ -428,6 +386,7 @@ fn wrap_hresult(x: HRESULT) -> io::Result<()> {
         DXGI_ERROR_UNSUPPORTED => ConnectionRefused,
         DXGI_ERROR_NOT_CURRENTLY_AVAILABLE => Interrupted,
         DXGI_ERROR_SESSION_DISCONNECTED => ConnectionAborted,
-        _ => Other
-    }).into())
+        _ => Other,
+    })
+    .into())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,15 @@
-#[macro_use]
-extern crate cfg_if;
-extern crate libc;
+#[cfg(quartz)]
+use block;
+#[cfg(quartz)]
+pub mod quartz;
 
-#[cfg(quartz)] extern crate block;
-#[cfg(quartz)] pub mod quartz;
+#[cfg(x11)]
+pub mod x11;
 
-#[cfg(x11)] pub mod x11;
-
-#[cfg(dxgi)] extern crate winapi;
-#[cfg(dxgi)] pub mod dxgi;
+#[cfg(dxgi)]
+use winapi;
+#[cfg(dxgi)]
+pub mod dxgi;
 
 mod common;
 pub use common::*;

--- a/src/quartz/config.rs
+++ b/src/quartz/config.rs
@@ -1,5 +1,7 @@
 use super::ffi::*;
+
 use libc::c_void;
+
 use std::ptr;
 
 //TODO: Color space, YCbCr matrix.
@@ -13,7 +15,7 @@ pub struct Config {
     /// How many frames are allocated.
     /// 3 is the recommended value.
     /// 8 is the maximum value.
-    pub queue_length: i8
+    pub queue_length: i8,
 }
 
 impl Config {
@@ -23,25 +25,25 @@ impl Config {
             let throttle = CFNumberCreate(
                 ptr::null_mut(),
                 CFNumberType::Float64,
-                &self.throttle as *const _ as *const c_void
+                &self.throttle as *const _ as *const c_void,
             );
             let queue_length = CFNumberCreate(
                 ptr::null_mut(),
                 CFNumberType::SInt8,
-                &self.queue_length as *const _ as *const c_void
+                &self.queue_length as *const _ as *const c_void,
             );
 
             let keys: [CFStringRef; 4] = [
                 kCGDisplayStreamShowCursor,
                 kCGDisplayStreamPreserveAspectRatio,
                 kCGDisplayStreamMinimumFrameTime,
-                kCGDisplayStreamQueueDepth
+                kCGDisplayStreamQueueDepth,
             ];
             let values: [*mut c_void; 4] = [
                 cfbool(self.cursor),
                 cfbool(self.letterbox),
                 throttle,
-                queue_length
+                queue_length,
             ];
 
             let res = CFDictionaryCreate(
@@ -50,7 +52,7 @@ impl Config {
                 values.as_ptr(),
                 4,
                 &kCFTypeDictionaryKeyCallBacks,
-                &kCFTypeDictionaryValueCallBacks
+                &kCFTypeDictionaryValueCallBacks,
             );
 
             CFRelease(throttle);
@@ -67,7 +69,7 @@ impl Default for Config {
             cursor: false,
             letterbox: true,
             throttle: 0.0,
-            queue_length: 3
+            queue_length: 3,
         }
     }
 }

--- a/src/quartz/display.rs
+++ b/src/quartz/display.rs
@@ -1,4 +1,5 @@
 use super::ffi::*;
+
 use std::mem;
 
 #[derive(PartialEq, Eq, Debug, Clone, Copy)]
@@ -17,7 +18,7 @@ impl Display {
 
             match CGGetOnlineDisplayList(16, arr.as_mut_ptr(), &mut len) {
                 CGError::Success => (),
-                x => return Err(x)
+                x => return Err(x),
             }
 
             let mut res = Vec::with_capacity(16);

--- a/src/quartz/ffi.rs
+++ b/src/quartz/ffi.rs
@@ -17,30 +17,31 @@ pub type CFAllocatorRef = *mut c_void;
 #[repr(C)]
 pub struct CFDictionaryKeyCallBacks {
     callbacks: [usize; 5],
-    version: i32
+    version: i32,
 }
 
 #[repr(C)]
 pub struct CFDictionaryValueCallBacks {
     callbacks: [usize; 4],
-    version: i32
+    version: i32,
 }
 
 macro_rules! pixel_format {
     ($a:expr, $b:expr, $c:expr, $d:expr) => {
-          ($a as i32) << 24
-        | ($b as i32) << 16
-        | ($c as i32) << 8
-        | ($d as i32)
-    }
+        ($a as i32) << 24 | ($b as i32) << 16 | ($c as i32) << 8 | ($d as i32)
+    };
 }
 
-pub const SURFACE_LOCK_READ_ONLY: u32  = 0x0000_0001;
+pub const SURFACE_LOCK_READ_ONLY: u32 = 0x0000_0001;
 pub const SURFACE_LOCK_AVOID_SYNC: u32 = 0x0000_0002;
 
 pub fn cfbool(x: bool) -> CFBooleanRef {
     unsafe {
-        if x { kCFBooleanTrue } else { kCFBooleanFalse }
+        if x {
+            kCFBooleanTrue
+        } else {
+            kCFBooleanFalse
+        }
     }
 }
 
@@ -56,7 +57,7 @@ pub enum CGDisplayStreamFrameStatus {
     /// The display stream was stopped.
     Stopped = 3,
     #[doc(hidden)]
-    __Nonexhaustive
+    __Nonexhaustive,
 }
 
 #[repr(i32)]
@@ -68,7 +69,7 @@ pub enum CFNumberType {
     SInt32 = 3,
     SInt64 = 4,
     Float32 = 5,
-    Float64 = 6,   /* 64-bit IEEE 754 */
+    Float64 = 6, /* 64-bit IEEE 754 */
     /* Basic C types */
     Char = 7,
     Short = 8,
@@ -80,7 +81,7 @@ pub enum CFNumberType {
     /* Other */
     CFIndex = 14,
     NSInteger = 15,
-    CGFloat = 16
+    CGFloat = 16,
 }
 
 #[repr(i32)]
@@ -99,38 +100,41 @@ pub enum CGError {
     InvalidOperation = 1010,
     NoneAvailable = 1011,
     #[doc(hidden)]
-    __Nonexhaustive
+    __Nonexhaustive,
 }
 
 #[repr(i32)]
 #[derive(PartialEq, Eq, Debug, Clone, Copy)]
 pub enum PixelFormat {
     /// Packed Little Endian ARGB8888
-    Argb8888 = pixel_format!('B','G','R','A'),
+    Argb8888 = pixel_format!('B', 'G', 'R', 'A'),
     /// Packed Little Endian ARGB2101010
-    Argb2101010 = pixel_format!('l','1','0','r'),
+    Argb2101010 = pixel_format!('l', '1', '0', 'r'),
     /// 2-plane "video" range YCbCr 4:2:0
-    YCbCr420Video = pixel_format!('4','2','0','v'),
+    YCbCr420Video = pixel_format!('4', '2', '0', 'v'),
     /// 2-plane "full" range YCbCr 4:2:0
-    YCbCr420Full = pixel_format!('4','2','0','f'),
+    YCbCr420Full = pixel_format!('4', '2', '0', 'f'),
     #[doc(hidden)]
-    __Nonexhaustive
+    __Nonexhaustive,
 }
 
 pub type CGDisplayStreamFrameAvailableHandler = *const c_void;
 
-pub type FrameAvailableHandler = RcBlock<(
-    CGDisplayStreamFrameStatus, // status
-    u64, // displayTime
-    IOSurfaceRef, // frameSurface
-    CGDisplayStreamUpdateRef // updateRef
-), ()>;
+pub type FrameAvailableHandler = RcBlock<
+    (
+        CGDisplayStreamFrameStatus, // status
+        u64,                        // displayTime
+        IOSurfaceRef,               // frameSurface
+        CGDisplayStreamUpdateRef,   // updateRef
+    ),
+    (),
+>;
 
-#[link(name="System", kind="dylib")]
-#[link(name="CoreGraphics", kind="framework")]
-#[link(name="CoreFoundation", kind="framework")]
-#[link(name="IOSurface", kind="framework")]
-extern {
+#[link(name = "System", kind = "dylib")]
+#[link(name = "CoreGraphics", kind = "framework")]
+#[link(name = "CoreFoundation", kind = "framework")]
+#[link(name = "IOSurface", kind = "framework")]
+extern "C" {
     // CoreGraphics
 
     pub static kCGDisplayStreamShowCursor: CFStringRef;
@@ -145,16 +149,12 @@ extern {
         pixel_format: PixelFormat,
         properties: CFDictionaryRef,
         queue: DispatchQueue,
-        handler: CGDisplayStreamFrameAvailableHandler
+        handler: CGDisplayStreamFrameAvailableHandler,
     ) -> CGDisplayStreamRef;
 
-    pub fn CGDisplayStreamStart(
-        displayStream: CGDisplayStreamRef
-    ) -> CGError;
+    pub fn CGDisplayStreamStart(displayStream: CGDisplayStreamRef) -> CGError;
 
-    pub fn CGDisplayStreamStop(
-        displayStream: CGDisplayStreamRef
-    ) -> CGError;
+    pub fn CGDisplayStreamStop(displayStream: CGDisplayStreamRef) -> CGError;
 
     pub fn CGMainDisplayID() -> u32;
     pub fn CGDisplayPixelsWide(display: u32) -> usize;
@@ -163,7 +163,7 @@ extern {
     pub fn CGGetOnlineDisplayList(
         max_displays: u32,
         online_displays: *mut u32,
-        display_count: *mut u32
+        display_count: *mut u32,
     ) -> CGError;
 
     pub fn CGDisplayIsBuiltin(display: u32) -> i32;
@@ -177,27 +177,14 @@ extern {
     pub fn IOSurfaceGetBaseAddress(buffer: IOSurfaceRef) -> *mut c_void;
     pub fn IOSurfaceIncrementUseCount(buffer: IOSurfaceRef);
     pub fn IOSurfaceDecrementUseCount(buffer: IOSurfaceRef);
-    pub fn IOSurfaceLock(
-        buffer: IOSurfaceRef,
-        options: u32,
-        seed: *mut u32
-    ) -> i32;
-    pub fn IOSurfaceUnlock(
-        buffer: IOSurfaceRef,
-        options: u32,
-        seed: *mut u32
-    ) -> i32;
+    pub fn IOSurfaceLock(buffer: IOSurfaceRef, options: u32, seed: *mut u32) -> i32;
+    pub fn IOSurfaceUnlock(buffer: IOSurfaceRef, options: u32, seed: *mut u32) -> i32;
 
     // Dispatch
 
-    pub fn dispatch_queue_create(
-        label: *const i8,
-        attr: DispatchQueueAttr
-    ) -> DispatchQueue;
+    pub fn dispatch_queue_create(label: *const i8, attr: DispatchQueueAttr) -> DispatchQueue;
 
-    pub fn dispatch_release(
-        object: DispatchQueue
-    );
+    pub fn dispatch_release(object: DispatchQueue);
 
     // Core Foundation
 
@@ -211,7 +198,7 @@ extern {
     pub fn CFNumberCreate(
         allocator: CFAllocatorRef,
         theType: CFNumberType,
-        valuePtr: *const c_void
+        valuePtr: *const c_void,
     ) -> CFNumberRef;
 
     pub fn CFDictionaryCreate(
@@ -220,7 +207,7 @@ extern {
         values: *const *mut c_void,
         numValues: i64,
         keyCallBacks: *const CFDictionaryKeyCallBacks,
-        valueCallBacks: *const CFDictionaryValueCallBacks
+        valueCallBacks: *const CFDictionaryValueCallBacks,
     ) -> CFDictionaryRef;
 
     pub fn CFRetain(cf: *const c_void);

--- a/src/quartz/frame.rs
+++ b/src/quartz/frame.rs
@@ -1,9 +1,10 @@
 use super::ffi::*;
+
 use std::{ops, ptr, slice};
 
 pub struct Frame {
     surface: IOSurfaceRef,
-    inner: &'static [u8]
+    inner: &'static [u8],
 }
 
 impl Frame {
@@ -11,15 +12,11 @@ impl Frame {
         CFRetain(surface);
         IOSurfaceIncrementUseCount(surface);
 
-        IOSurfaceLock(
-            surface,
-            SURFACE_LOCK_READ_ONLY,
-            ptr::null_mut()
-        );
+        IOSurfaceLock(surface, SURFACE_LOCK_READ_ONLY, ptr::null_mut());
 
         let inner = slice::from_raw_parts(
             IOSurfaceGetBaseAddress(surface) as *const u8,
-            IOSurfaceGetAllocSize(surface)
+            IOSurfaceGetAllocSize(surface),
         );
 
         Frame { surface, inner }
@@ -36,11 +33,7 @@ impl ops::Deref for Frame {
 impl Drop for Frame {
     fn drop(&mut self) {
         unsafe {
-            IOSurfaceUnlock(
-                self.surface,
-                SURFACE_LOCK_READ_ONLY,
-                ptr::null_mut()
-            );
+            IOSurfaceUnlock(self.surface, SURFACE_LOCK_READ_ONLY, ptr::null_mut());
 
             IOSurfaceDecrementUseCount(self.surface);
             CFRelease(self.surface);

--- a/src/x11/display.rs
+++ b/src/x11/display.rs
@@ -1,6 +1,7 @@
-use std::rc::Rc;
-use super::Server;
 use super::ffi::*;
+use super::Server;
+
+use std::rc::Rc;
 
 #[derive(Debug)]
 pub struct Display {
@@ -19,17 +20,32 @@ pub struct Rect {
 }
 
 impl Display {
+    ///
+    /// # Safety
     pub unsafe fn new(
         server: Rc<Server>,
         default: bool,
         rect: Rect,
-        root: xcb_window_t
+        root: xcb_window_t,
     ) -> Display {
-        Display { server, default, rect, root }
+        Display {
+            server,
+            default,
+            rect,
+            root,
+        }
     }
 
-    pub fn server(&self) -> &Rc<Server> { &self.server }
-    pub fn is_default(&self) -> bool { self.default }
-    pub fn rect(&self) -> Rect { self.rect }
-    pub fn root(&self) -> xcb_window_t { self.root }
+    pub fn server(&self) -> &Rc<Server> {
+        &self.server
+    }
+    pub fn is_default(&self) -> bool {
+        self.default
+    }
+    pub fn rect(&self) -> Rect {
+        self.rect
+    }
+    pub fn root(&self) -> xcb_window_t {
+        self.root
+    }
 }

--- a/src/x11/server.rs
+++ b/src/x11/server.rs
@@ -1,45 +1,54 @@
+use super::ffi::*;
+use super::DisplayIter;
+
 use std::ptr;
 use std::rc::Rc;
-use super::DisplayIter;
-use super::ffi::*;
 
 #[derive(Debug)]
 pub struct Server {
     raw: *mut xcb_connection_t,
     screenp: i32,
-    setup: *const xcb_setup_t
+    setup: *const xcb_setup_t,
 }
 
 impl Server {
     pub fn displays(slf: Rc<Server>) -> DisplayIter {
-        unsafe {
-            DisplayIter::new(slf)
-        }
+        unsafe { DisplayIter::new(slf) }
     }
 
     pub fn default() -> Result<Server, Error> {
-        Server::connect(ptr::null())
+        unsafe { Server::connect(ptr::null()) }
     }
 
-    pub fn connect(addr: *const i8) -> Result<Server, Error> {
-        unsafe {
-            let mut screenp = 0;
-            let raw = xcb_connect(addr, &mut screenp);
+    ///
+    /// # Safety
+    pub unsafe fn connect(addr: *const i8) -> Result<Server, Error> {
+        let mut screenp = 0;
+        let raw = xcb_connect(addr, &mut screenp);
 
-            let error = xcb_connection_has_error(raw);
-            if error != 0 {
-                xcb_disconnect(raw);
-                Err(Error::from(error))
-            } else {
-                let setup = xcb_get_setup(raw);
-                Ok(Server { raw, screenp, setup })
-            }
+        let error = xcb_connection_has_error(raw);
+        if error != 0 {
+            xcb_disconnect(raw);
+            Err(Error::from(error))
+        } else {
+            let setup = xcb_get_setup(raw);
+            Ok(Server {
+                raw,
+                screenp,
+                setup,
+            })
         }
     }
 
-    pub fn raw(&self) -> *mut xcb_connection_t { self.raw }
-    pub fn screenp(&self) -> i32 { self.screenp }
-    pub fn setup(&self) -> *const xcb_setup_t { self.setup }
+    pub fn raw(&self) -> *mut xcb_connection_t {
+        self.raw
+    }
+    pub fn screenp(&self) -> i32 {
+        self.screenp
+    }
+    pub fn setup(&self) -> *const xcb_setup_t {
+        self.setup
+    }
 }
 
 impl Drop for Server {
@@ -57,7 +66,7 @@ pub enum Error {
     InsufficientMemory,
     RequestTooLong,
     ParseError,
-    InvalidScreen
+    InvalidScreen,
 }
 
 impl From<i32> for Error {
@@ -69,7 +78,7 @@ impl From<i32> for Error {
             4 => RequestTooLong,
             5 => ParseError,
             6 => InvalidScreen,
-            _ => Generic
+            _ => Generic,
         }
     }
 }


### PR DESCRIPTION
Great crate this has been really fun to use! This PR fixes all clippy lints caused by updating to the 2018 rust edition.