### PR TITLE
Fix comment in the example

### DIFF
--- a/examples/screenshot.rs
+++ b/examples/screenshot.rs
@@ -33,7 +33,7 @@ fn main() {
 
         println!("Captured! Saving...");
 
-        // Flip the ARGB image into a BGRA image.
+        // Flip the BGRA image into a RGBA image.
 
         let mut bitflipped = Vec::with_capacity(w * h * 4);
         let stride = buffer.len() / h;


### PR DESCRIPTION
I assume this is just a small typo, given Apple / Win output BGRA and the library guarantees to output packed BGRA.
Also repng::encode expect a RGBA image