### PR TITLE
Use real screen size

### DIFF
--- a/src/quartz/display.rs
+++ b/src/quartz/display.rs
@@ -33,11 +33,17 @@ impl Display {
     }
 
     pub fn width(self) -> usize {
-        unsafe { CGDisplayPixelsWide(self.0) }
+        unsafe {
+            let display_mode = CGDisplayCopyDisplayMode(self.0);
+            CGDisplayModeGetPixelWidth(display_mode)
+        }
     }
 
     pub fn height(self) -> usize {
-        unsafe { CGDisplayPixelsHigh(self.0) }
+        unsafe {
+            let display_mode = CGDisplayCopyDisplayMode(self.0);
+            CGDisplayModeGetPixelHeight(display_mode)
+        }
     }
 
     pub fn is_builtin(self) -> bool {

--- a/src/quartz/ffi.rs
+++ b/src/quartz/ffi.rs
@@ -26,6 +26,9 @@ pub struct CFDictionaryValueCallBacks {
     version: i32
 }
 
+pub enum CGDisplayMode {}
+pub type CGDisplayModeRef = *mut CGDisplayMode;
+
 macro_rules! pixel_format {
     ($a:expr, $b:expr, $c:expr, $d:expr) => {
           ($a as i32) << 24
@@ -157,6 +160,14 @@ extern {
     ) -> CGError;
 
     pub fn CGMainDisplayID() -> u32;
+    pub fn CGDisplayCopyDisplayMode(display: u32) -> CGDisplayModeRef;
+    // pub fn CGDisplayModeGetHeight(mode: CGDisplayModeRef) -> libc::size_t;
+    // pub fn CGDisplayModeGetWidth(mode: CGDisplayModeRef) -> libc::size_t;
+    pub fn CGDisplayModeGetPixelHeight(mode: CGDisplayModeRef) -> libc::size_t;
+    pub fn CGDisplayModeGetPixelWidth(mode: CGDisplayModeRef) -> libc::size_t;
+    // pub fn CGDisplayModeGetRefreshRate(mode: CGDisplayModeRef) -> libc::c_double;
+    // pub fn CGDisplayModeGetIOFlags(mode: CGDisplayModeRef) -> u32;
+    // pub fn CGDisplayModeCopyPixelEncoding(mode: CGDisplayModeRef) -> CFStringRef;
     pub fn CGDisplayPixelsWide(display: u32) -> usize;
     pub fn CGDisplayPixelsHigh(display: u32) -> usize;
 


### PR DESCRIPTION
fix https://github.com/quadrupleslap/scrap/issues/20

## Description

I am not expert of the macos screen resolution, but we can split:

* the physical size of the screen `2880 x 1800`
* the "resolution" / scale -> `1680 x 1050` (can change depending on the scaling settings
* the size of the screen that the system is using before scaling down ( x2 the resolution / scale) -> `3360 x 2100`


this patch is using the 3 data -> `the size of the screen that the system is using before scaling down` -> which is the same behavior that the macos `PrtScn` is using